### PR TITLE
docs: share same PR template with zkbas repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,17 @@
----
-name: Pull Request report
-about: Create a PR report to apply for code merge or feature test.
-title: ''
-labels: ''
-assignees: ''
+### Description
 
----
+add a description of your changes here...
 
-## Proposed changes
+### Rationale
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+tell us why we need these changes...
 
-## Types of changes
+### Example
 
-What types of changes does your code introduce to Appium?
-_Put an `x` in the boxes that apply_
+add an example CLI or API response...
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation Update (if none of the other choices apply)
+### Changes
 
-## Checklist
-
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-
-- [ ] I have read the Contributing doc
-- [ ] Lint and unit tests pass locally with my changes
-- [ ] I have added annotation in every module or function of my work
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added necessary documentation like README.md (if appropriate)
-- [ ] Any dependent changes should support downstream modules, if not, should add admin in this organization as reviewer to discuss
-
-## Further comments
-
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+Notable changes:
+* add each change in a bullet point here
+* ...


### PR DESCRIPTION
### Description
This PR just submit a new PR template.

### Rationale
crypto repo should share the same PR template as zkbas

### Example
No

### Changes

Notable changes:
Please follow the new template in the following PRs.