### PR TITLE
tx types: make compute msg hash a method

### DIFF
--- a/wasm/legend/legendTxTypes/addLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/addLiquidityTypes.go
@@ -86,7 +86,7 @@ func ConstructAddLiquidityTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Add
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructAddLiquidityTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -188,7 +188,7 @@ func (txInfo *AddLiquidityTxInfo) Validate() error {
 func (txInfo *AddLiquidityTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (txInfo *AddLiquidityTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *AddLiquidityTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *AddLiquidityTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAAmount)

--- a/wasm/legend/legendTxTypes/addLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/addLiquidityTypes.go
@@ -86,7 +86,7 @@ func ConstructAddLiquidityTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Add
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeAddLiquidityMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructAddLiquidityTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -188,7 +188,7 @@ func (txInfo *AddLiquidityTxInfo) Validate() error {
 func (txInfo *AddLiquidityTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeAddLiquidityMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (txInfo *AddLiquidityTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeAddLiquidityMsgHash(txInfo *AddLiquidityTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *AddLiquidityTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAAmount)

--- a/wasm/legend/legendTxTypes/atomicMatchTypes.go
+++ b/wasm/legend/legendTxTypes/atomicMatchTypes.go
@@ -89,7 +89,7 @@ func ConstructAtomicMatchTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Atom
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash: ", err.Error())
 		return nil, err
@@ -182,7 +182,7 @@ func (txInfo *AtomicMatchTxInfo) Validate() error {
 func (txInfo *AtomicMatchTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (txInfo *AtomicMatchTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *AtomicMatchTxInfo)ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *AtomicMatchTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedBuyAmount, err := ToPackedAmount(txInfo.BuyOffer.AssetAmount)

--- a/wasm/legend/legendTxTypes/atomicMatchTypes.go
+++ b/wasm/legend/legendTxTypes/atomicMatchTypes.go
@@ -89,7 +89,7 @@ func ConstructAtomicMatchTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Atom
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeAtomicMatchMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash: ", err.Error())
 		return nil, err
@@ -182,7 +182,7 @@ func (txInfo *AtomicMatchTxInfo) Validate() error {
 func (txInfo *AtomicMatchTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeAtomicMatchMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (txInfo *AtomicMatchTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeAtomicMatchMsgHash(txInfo *AtomicMatchTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *AtomicMatchTxInfo)ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedBuyAmount, err := ToPackedAmount(txInfo.BuyOffer.AssetAmount)

--- a/wasm/legend/legendTxTypes/cancelOfferTypes.go
+++ b/wasm/legend/legendTxTypes/cancelOfferTypes.go
@@ -68,7 +68,7 @@ func ConstructCancelOfferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Canc
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -147,7 +147,7 @@ func (txInfo *CancelOfferTxInfo) Validate() error {
 func (txInfo *CancelOfferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (txInfo *CancelOfferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *CancelOfferTxInfo) ComputeMsgHash (hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *CancelOfferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/cancelOfferTypes.go
+++ b/wasm/legend/legendTxTypes/cancelOfferTypes.go
@@ -68,7 +68,7 @@ func ConstructCancelOfferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Canc
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeCancelOfferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -147,7 +147,7 @@ func (txInfo *CancelOfferTxInfo) Validate() error {
 func (txInfo *CancelOfferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeCancelOfferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (txInfo *CancelOfferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeCancelOfferMsgHash(txInfo *CancelOfferTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *CancelOfferTxInfo) ComputeMsgHash (hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/createCollection.go
+++ b/wasm/legend/legendTxTypes/createCollection.go
@@ -70,7 +70,7 @@ func ConstructCreateCollectionTxInfo(sk *PrivateKey, segmentStr string) (txInfo 
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeCreateCollectionMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructCreateCollectionTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -159,7 +159,7 @@ func (txInfo *CreateCollectionTxInfo) Validate() error {
 func (txInfo *CreateCollectionTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeCreateCollectionMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (txInfo *CreateCollectionTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeCreateCollectionMsgHash(txInfo *CreateCollectionTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *CreateCollectionTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/createCollection.go
+++ b/wasm/legend/legendTxTypes/createCollection.go
@@ -70,7 +70,7 @@ func ConstructCreateCollectionTxInfo(sk *PrivateKey, segmentStr string) (txInfo 
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructCreateCollectionTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -159,7 +159,7 @@ func (txInfo *CreateCollectionTxInfo) Validate() error {
 func (txInfo *CreateCollectionTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (txInfo *CreateCollectionTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *CreateCollectionTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *CreateCollectionTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/createPairTypes.go
+++ b/wasm/legend/legendTxTypes/createPairTypes.go
@@ -41,6 +41,6 @@ func (txInfo *CreatePairTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *CreatePairTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *CreatePairTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/createPairTypes.go
+++ b/wasm/legend/legendTxTypes/createPairTypes.go
@@ -1,5 +1,10 @@
 package legendTxTypes
 
+import (
+	"errors"
+	"hash"
+)
+
 type CreatePairTxInfo struct {
 	TxType uint8
 
@@ -34,4 +39,8 @@ func (txInfo *CreatePairTxInfo) GetNonce() int64 {
 
 func (txInfo *CreatePairTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *CreatePairTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/depositNftTypes.go
+++ b/wasm/legend/legendTxTypes/depositNftTypes.go
@@ -1,6 +1,10 @@
 package legendTxTypes
 
-import "math/big"
+import (
+	"errors"
+	"hash"
+	"math/big"
+)
 
 type DepositNftTxInfo struct {
 	TxType uint8
@@ -43,4 +47,8 @@ func (txInfo *DepositNftTxInfo) GetNonce() int64 {
 
 func (txInfo *DepositNftTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *DepositNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/depositNftTypes.go
+++ b/wasm/legend/legendTxTypes/depositNftTypes.go
@@ -49,6 +49,6 @@ func (txInfo *DepositNftTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *DepositNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *DepositNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/deposityTxTypes.go
+++ b/wasm/legend/legendTxTypes/deposityTxTypes.go
@@ -42,6 +42,6 @@ func (txInfo *DepositTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *DepositTxInfo)  ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *DepositTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/deposityTxTypes.go
+++ b/wasm/legend/legendTxTypes/deposityTxTypes.go
@@ -1,6 +1,10 @@
 package legendTxTypes
 
-import "math/big"
+import (
+	"errors"
+	"hash"
+	"math/big"
+)
 
 type DepositTxInfo struct {
 	TxType uint8
@@ -36,4 +40,8 @@ func (txInfo *DepositTxInfo) GetNonce() int64 {
 
 func (txInfo *DepositTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *DepositTxInfo)  ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/fullExitNftTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitNftTypes.go
@@ -48,6 +48,6 @@ func (txInfo *FullExitNftTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *FullExitNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *FullExitNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/fullExitNftTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitNftTypes.go
@@ -1,6 +1,10 @@
 package legendTxTypes
 
-import "math/big"
+import (
+	"errors"
+	"hash"
+	"math/big"
+)
 
 type FullExitNftTxInfo struct {
 	TxType uint8
@@ -42,4 +46,8 @@ func (txInfo *FullExitNftTxInfo) GetNonce() int64 {
 
 func (txInfo *FullExitNftTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *FullExitNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/fullExitTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitTypes.go
@@ -1,6 +1,10 @@
 package legendTxTypes
 
-import "math/big"
+import (
+	"errors"
+	"hash"
+	"math/big"
+)
 
 type FullExitTxInfo struct {
 	TxType uint8
@@ -36,4 +40,8 @@ func (txInfo *FullExitTxInfo) GetNonce() int64 {
 
 func (txInfo *FullExitTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *FullExitTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/fullExitTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitTypes.go
@@ -42,6 +42,6 @@ func (txInfo *FullExitTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *FullExitTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *FullExitTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/interface.go
+++ b/wasm/legend/legendTxTypes/interface.go
@@ -15,5 +15,5 @@ type TxInfo interface {
 
 	GetExpiredAt() int64
 
-	ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error)
+	Hash(hFunc hash.Hash) (msgHash []byte, err error)
 }

--- a/wasm/legend/legendTxTypes/interface.go
+++ b/wasm/legend/legendTxTypes/interface.go
@@ -1,5 +1,7 @@
 package legendTxTypes
 
+import "hash"
+
 type TxInfo interface {
 	GetTxType() int
 
@@ -12,4 +14,6 @@ type TxInfo interface {
 	GetNonce() int64
 
 	GetExpiredAt() int64
+
+	ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error)
 }

--- a/wasm/legend/legendTxTypes/mintNftTypes.go
+++ b/wasm/legend/legendTxTypes/mintNftTypes.go
@@ -80,7 +80,7 @@ func ConstructMintNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *MintNftT
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -193,7 +193,7 @@ func (txInfo *MintNftTxInfo) Validate() error {
 func (txInfo *MintNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (txInfo *MintNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *MintNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *MintNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/mintNftTypes.go
+++ b/wasm/legend/legendTxTypes/mintNftTypes.go
@@ -80,7 +80,7 @@ func ConstructMintNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *MintNftT
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeMintNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructMintNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -193,7 +193,7 @@ func (txInfo *MintNftTxInfo) Validate() error {
 func (txInfo *MintNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeMintNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (txInfo *MintNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeMintNftMsgHash(txInfo *MintNftTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *MintNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/offerTypes.go
+++ b/wasm/legend/legendTxTypes/offerTypes.go
@@ -77,7 +77,7 @@ func ConstructOfferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *OfferTxInf
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (txInfo *OfferTxInfo) Validate() error {
 func (txInfo *OfferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (txInfo *OfferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *OfferTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *OfferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAmount, err := ToPackedAmount(txInfo.AssetAmount)

--- a/wasm/legend/legendTxTypes/offerTypes.go
+++ b/wasm/legend/legendTxTypes/offerTypes.go
@@ -77,7 +77,7 @@ func ConstructOfferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *OfferTxInf
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeOfferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (txInfo *OfferTxInfo) Validate() error {
 func (txInfo *OfferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeOfferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (txInfo *OfferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeOfferMsgHash(txInfo *OfferTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *OfferTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAmount, err := ToPackedAmount(txInfo.AssetAmount)

--- a/wasm/legend/legendTxTypes/registerZnsTypes.go
+++ b/wasm/legend/legendTxTypes/registerZnsTypes.go
@@ -1,5 +1,10 @@
 package legendTxTypes
 
+import (
+	"errors"
+	"hash"
+)
+
 type RegisterZnsTxInfo struct {
 	TxType uint8
 
@@ -32,4 +37,8 @@ func (txInfo *RegisterZnsTxInfo) GetNonce() int64 {
 
 func (txInfo *RegisterZnsTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *RegisterZnsTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/registerZnsTypes.go
+++ b/wasm/legend/legendTxTypes/registerZnsTypes.go
@@ -39,6 +39,6 @@ func (txInfo *RegisterZnsTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *RegisterZnsTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *RegisterZnsTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/removeLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/removeLiquidityTypes.go
@@ -109,7 +109,7 @@ func ConstructRemoveLiquidityTxInfo(sk *PrivateKey, segmentStr string) (txInfo *
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructRemoveLiquidityTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -223,7 +223,7 @@ func (txInfo *RemoveLiquidityTxInfo) Validate() error {
 func (txInfo *RemoveLiquidityTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (txInfo *RemoveLiquidityTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *RemoveLiquidityTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *RemoveLiquidityTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAMinAmount)

--- a/wasm/legend/legendTxTypes/removeLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/removeLiquidityTypes.go
@@ -109,7 +109,7 @@ func ConstructRemoveLiquidityTxInfo(sk *PrivateKey, segmentStr string) (txInfo *
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeRemoveLiquidityMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructRemoveLiquidityTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -223,7 +223,7 @@ func (txInfo *RemoveLiquidityTxInfo) Validate() error {
 func (txInfo *RemoveLiquidityTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeRemoveLiquidityMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (txInfo *RemoveLiquidityTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeRemoveLiquidityMsgHash(txInfo *RemoveLiquidityTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *RemoveLiquidityTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAMinAmount)

--- a/wasm/legend/legendTxTypes/swapTypes.go
+++ b/wasm/legend/legendTxTypes/swapTypes.go
@@ -91,7 +91,7 @@ func ConstructSwapTxInfo(sk *PrivateKey, segmentStr string) (txInfo *SwapTxInfo,
 		Sig:               nil,
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructSwapTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -204,7 +204,7 @@ func (txInfo *SwapTxInfo) Validate() error {
 func (txInfo *SwapTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (txInfo *SwapTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *SwapTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *SwapTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAAmount)

--- a/wasm/legend/legendTxTypes/swapTypes.go
+++ b/wasm/legend/legendTxTypes/swapTypes.go
@@ -91,7 +91,7 @@ func ConstructSwapTxInfo(sk *PrivateKey, segmentStr string) (txInfo *SwapTxInfo,
 		Sig:               nil,
 	}
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeSwapMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructSwapTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -204,7 +204,7 @@ func (txInfo *SwapTxInfo) Validate() error {
 func (txInfo *SwapTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeSwapMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (txInfo *SwapTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeSwapMsgHash(txInfo *SwapTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *SwapTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAAmount, err := ToPackedAmount(txInfo.AssetAAmount)

--- a/wasm/legend/legendTxTypes/transferNftTypes.go
+++ b/wasm/legend/legendTxTypes/transferNftTypes.go
@@ -81,7 +81,7 @@ func ConstructTransferNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Tran
 	callDataHash := hFunc.Sum(nil)
 	txInfo.CallDataHash = callDataHash
 	hFunc.Reset()
-	msgHash, err := ComputeTransferNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructTransferNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -185,7 +185,7 @@ func (txInfo *TransferNftTxInfo) Validate() error {
 func (txInfo *TransferNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeTransferNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func (txInfo *TransferNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeTransferNftMsgHash(txInfo *TransferNftTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *TransferNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/transferNftTypes.go
+++ b/wasm/legend/legendTxTypes/transferNftTypes.go
@@ -81,7 +81,7 @@ func ConstructTransferNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Tran
 	callDataHash := hFunc.Sum(nil)
 	txInfo.CallDataHash = callDataHash
 	hFunc.Reset()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructTransferNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -185,7 +185,7 @@ func (txInfo *TransferNftTxInfo) Validate() error {
 func (txInfo *TransferNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func (txInfo *TransferNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *TransferNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *TransferNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/transferTypes.go
+++ b/wasm/legend/legendTxTypes/transferTypes.go
@@ -93,7 +93,7 @@ func ConstructTransferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Transfe
 	txInfo.CallDataHash = callDataHash
 	hFunc.Reset()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructTransferTxInfo] unable to compute hash:", err.Error())
 		return nil, err
@@ -202,7 +202,7 @@ func (txInfo *TransferTxInfo) Validate() error {
 func (txInfo *TransferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (txInfo *TransferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *TransferTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *TransferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAmount, err := ToPackedAmount(txInfo.AssetAmount)

--- a/wasm/legend/legendTxTypes/transferTypes.go
+++ b/wasm/legend/legendTxTypes/transferTypes.go
@@ -93,7 +93,7 @@ func ConstructTransferTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Transfe
 	txInfo.CallDataHash = callDataHash
 	hFunc.Reset()
 	// compute msg hash
-	msgHash, err := ComputeTransferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructTransferTxInfo] unable to compute hash:", err.Error())
 		return nil, err
@@ -202,7 +202,7 @@ func (txInfo *TransferTxInfo) Validate() error {
 func (txInfo *TransferTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeTransferMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (txInfo *TransferTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeTransferMsgHash(txInfo *TransferTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *TransferTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedAmount, err := ToPackedAmount(txInfo.AssetAmount)

--- a/wasm/legend/legendTxTypes/updatePairRateTypes.go
+++ b/wasm/legend/legendTxTypes/updatePairRateTypes.go
@@ -1,5 +1,10 @@
 package legendTxTypes
 
+import (
+	"errors"
+	"hash"
+)
+
 type UpdatePairRateTxInfo struct {
 	TxType uint8
 
@@ -32,4 +37,8 @@ func (txInfo *UpdatePairRateTxInfo) GetNonce() int64 {
 
 func (txInfo *UpdatePairRateTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
+}
+
+func (txInfo *UpdatePairRateTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/updatePairRateTypes.go
+++ b/wasm/legend/legendTxTypes/updatePairRateTypes.go
@@ -39,6 +39,6 @@ func (txInfo *UpdatePairRateTxInfo) GetExpiredAt() int64 {
 	return NilExpiredAt
 }
 
-func (txInfo *UpdatePairRateTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *UpdatePairRateTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }

--- a/wasm/legend/legendTxTypes/withdrawNftTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawNftTypes.go
@@ -67,7 +67,7 @@ func ConstructWithdrawNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *With
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeWithdrawNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructWithdrawNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -162,7 +162,7 @@ func (txInfo *WithdrawNftTxInfo) Validate() error {
 func (txInfo *WithdrawNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeWithdrawNftMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (txInfo *WithdrawNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeWithdrawNftMsgHash(txInfo *WithdrawNftTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *WithdrawNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/withdrawNftTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawNftTypes.go
@@ -67,7 +67,7 @@ func ConstructWithdrawNftTxInfo(sk *PrivateKey, segmentStr string) (txInfo *With
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructWithdrawNftTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -162,7 +162,7 @@ func (txInfo *WithdrawNftTxInfo) Validate() error {
 func (txInfo *WithdrawNftTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (txInfo *WithdrawNftTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *WithdrawNftTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *WithdrawNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/withdrawTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawTypes.go
@@ -75,7 +75,7 @@ func ConstructWithdrawTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Withdra
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := ComputeWithdrawMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		log.Println("[ConstructWithdrawTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -168,7 +168,7 @@ func (txInfo *WithdrawTxInfo) Validate() error {
 func (txInfo *WithdrawTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := ComputeWithdrawMsgHash(txInfo, hFunc)
+	msgHash, err := txInfo.ComputeMsgHash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (txInfo *WithdrawTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func ComputeWithdrawMsgHash(txInfo *WithdrawTxInfo, hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *WithdrawTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)

--- a/wasm/legend/legendTxTypes/withdrawTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawTypes.go
@@ -75,7 +75,7 @@ func ConstructWithdrawTxInfo(sk *PrivateKey, segmentStr string) (txInfo *Withdra
 	// compute call data hash
 	hFunc := mimc.NewMiMC()
 	// compute msg hash
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		log.Println("[ConstructWithdrawTxInfo] unable to compute hash:", err)
 		return nil, err
@@ -168,7 +168,7 @@ func (txInfo *WithdrawTxInfo) Validate() error {
 func (txInfo *WithdrawTxInfo) VerifySignature(pubKey string) error {
 	// compute hash
 	hFunc := mimc.NewMiMC()
-	msgHash, err := txInfo.ComputeMsgHash(hFunc)
+	msgHash, err := txInfo.Hash(hFunc)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (txInfo *WithdrawTxInfo) GetExpiredAt() int64 {
 	return txInfo.ExpiredAt
 }
 
-func (txInfo *WithdrawTxInfo) ComputeMsgHash(hFunc hash.Hash) (msgHash []byte, err error) {
+func (txInfo *WithdrawTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	hFunc.Reset()
 	var buf bytes.Buffer
 	packedFee, err := ToPackedFee(txInfo.GasFeeAssetAmount)


### PR DESCRIPTION
### Description

Make compute msg hash as an interface method, all tx types have the same function name.

### Rationale

When we compute different tx's hash, we should call different functions, so the caller must distinguish the different tx types and then call the related function that computes its msg hash, this is not simple enough, we can define compute msg hash as an interface method to avoid this.

### Example

NA

### Changes

Notable changes:
* NA