### PR TITLE
refactor: reduce public inputs of block constraints

### DIFF
--- a/circuit/block_constraints.go
+++ b/circuit/block_constraints.go
@@ -28,8 +28,8 @@ import (
 type BlockConstraints struct {
 	BlockNumber     Variable
 	CreatedAt       Variable
-	OldStateRoot    Variable `gnark:",public"`
-	NewStateRoot    Variable `gnark:",public"`
+	OldStateRoot    Variable
+	NewStateRoot    Variable
 	BlockCommitment Variable `gnark:",public"`
 	Txs             []TxConstraints
 	TxsCount        int


### PR DESCRIPTION
### Description

This pr will reduce the public inputs of block contraints. It will delete `OldStateRoot` and `NewStateRoot` since they are included in the commitment already.

### Changes

Notable changes:
* reduce public inputs of block constraints