### PR TITLE
feat: update gnark version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 )
 
 replace (
-	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69
+	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20221118113915-b79c55c6156d
 	github.com/consensys/gnark-crypto => github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262
 )

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69 h1:opczrQy0kE8rDlLjhj4b56k8t8GrHZ/eV1OjmQalh74=
-github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69/go.mod h1:J5is/1NQUxPfIDDG/x/+TBX2c0byx48KiLRLCheby1A=
+github.com/bnb-chain/gnark v0.7.1-0.20221118113915-b79c55c6156d h1:yUXu5VU+KJLfS9UkudC/stPsY1F6c8mT8B7bE0Qp5Sk=
+github.com/bnb-chain/gnark v0.7.1-0.20221118113915-b79c55c6156d/go.mod h1:J5is/1NQUxPfIDDG/x/+TBX2c0byx48KiLRLCheby1A=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262 h1:kYHgB6keVdBf07XcCFnpvG6rNI40hUWL0Z1JStn62g4=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
### Description
Update gnark version to fix the r1cs file dump issue

### Rationale

### Example

### Changes

Notable changes: