### PR TITLE
calc hash by using sha256 to not lose seed data

### DIFF
--- a/ecc/ztwistededwards/tebn254/eddsa.go
+++ b/ecc/ztwistededwards/tebn254/eddsa.go
@@ -19,7 +19,9 @@ package tebn254
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"io"
 	"math/big"
 
@@ -32,9 +34,13 @@ import (
 	GenerateEddsaPrivateKey: generate eddsa private key
 */
 func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
-	buf := make([]byte, 32)
-	copy(buf, seed)
-	reader := bytes.NewReader(buf)
+	buf, err := hex.DecodeString(seed)
+	if err != nil {
+		return nil, err
+	}
+	// calc hash by using sha256 to not lose seed data
+	hash := sha256.Sum256(buf)
+	reader := bytes.NewReader(hash[:])
 	sk, err = GenerateKey(reader)
 	return sk, err
 }


### PR DESCRIPTION
### Description
calc hash by using sha256 to not lose seed data

### Rationale

The old logic only takes the previous string with a length of 32, which will cause the seed to be truncated and lost some data. Even the hex string of 32 bytes will be truncated. This version is to fix the issue of seed loss
### Example
<img width="877" alt="截屏2022-12-07 11 28 02" src="https://user-images.githubusercontent.com/24997729/206081146-08498ec5-652c-4e78-9abb-5a182b1d00ad.png">

### Changes

Notable changes:
* Decode the seed and hash the decode result by sha256