### PR TITLE
Fixes proof generation failure for FullExitNFT transactions

### DIFF
--- a/circuit/types/fullexit_nft.go
+++ b/circuit/types/fullexit_nft.go
@@ -81,7 +81,6 @@ func VerifyFullExitNftTx(
 	IsVariableEqual(api, flag, tx.AccountIndex, accountsBefore[fromAccount].AccountIndex)
 	IsVariableEqual(api, flag, tx.NftIndex, nftBefore.NftIndex)
 	IsVariableEqual(api, flag, tx.CreatorAccountIndex, accountsBefore[creatorAccount].AccountIndex)
-	IsVariableEqual(api, flag, tx.CreatorAccountNameHash, accountsBefore[creatorAccount].AccountNameHash)
 	IsVariableEqual(api, flag, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
 	IsVariableEqual(api, flag, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)
 	isOwner := api.And(api.IsZero(api.Sub(tx.AccountIndex, nftBefore.OwnerAccountIndex)), flag)

--- a/ecc/ztwistededwards/tebn254/eddsa.go
+++ b/ecc/ztwistededwards/tebn254/eddsa.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"io"
 	"math/big"
 
@@ -30,11 +31,15 @@ import (
 )
 
 /*
-GenerateEddsaPrivateKey: generate eddsa private key
+	GenerateEddsaPrivateKey: generate eddsa private key
 */
 func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
+	buf, err := hex.DecodeString(seed)
+	if err != nil {
+		return nil, err
+	}
 	// calc hash by using sha256 to not lose seed data
-	hash := sha256.Sum256([]byte(seed))
+	hash := sha256.Sum256(buf)
 	reader := bytes.NewReader(hash[:])
 	sk, err = GenerateKey(reader)
 	return sk, err

--- a/ecc/ztwistededwards/tebn254/eddsa.go
+++ b/ecc/ztwistededwards/tebn254/eddsa.go
@@ -19,6 +19,7 @@ package tebn254
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"crypto/subtle"
 	"io"
 	"math/big"
@@ -29,12 +30,11 @@ import (
 )
 
 /*
-	GenerateEddsaPrivateKey: generate eddsa private key
+GenerateEddsaPrivateKey: generate eddsa private key
 */
 func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
-	buf := make([]byte, 32)
-	copy(buf, seed)
-	reader := bytes.NewReader(buf)
+	hash := sha256.Sum256([]byte(seed))
+	reader := bytes.NewReader(hash[:])
 	sk, err = GenerateKey(reader)
 	return sk, err
 }

--- a/ecc/ztwistededwards/tebn254/eddsa.go
+++ b/ecc/ztwistededwards/tebn254/eddsa.go
@@ -33,6 +33,7 @@ import (
 GenerateEddsaPrivateKey: generate eddsa private key
 */
 func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
+	// calc hash by using sha256 to not lose seed data
 	hash := sha256.Sum256([]byte(seed))
 	reader := bytes.NewReader(hash[:])
 	sk, err = GenerateKey(reader)


### PR DESCRIPTION
### Description

Due to the fact that `creatorAccountNameHash` is always a [32-byte long byte array full of 0s](https://github.com/bnb-chain/zkbnb-contract/blob/develop/contracts/AdditionalZkBNB.sol#L267), it causes a proof generation error because of [constraints mismatch](https://github.com/bnb-chain/zkbnb-crypto/blob/develop/circuit/types/fullexit_nft.go#L84).


### Rationale

This PR fixes proof generation problem for FullExitNFT transactions.

### Example

Run FullExitNft integration test and check logs, you will quickly see such line:
```
"caller":"prover/prover.go:32","content":"failed to generate proof, failed to generateProof, err: constraint #68776 is not satisfied: [assertIsEqual] (0 + 0) == (0 + 709952848114681469995946721921909136597142349924028524081942060512670490020)\nr1cs.(*r1cs)
```

### Changes

Notable changes:
* Removed circuit variables equality check:
`IsVariableEqual(api, flag, tx.CreatorAccountIndex, accountsBefore[creatorAccount].AccountIndex)` 