### PR TITLE
Fixes FullExitNFT transactions proof validation 

### DIFF
--- a/circuit/asset_delta.go
+++ b/circuit/asset_delta.go
@@ -483,13 +483,23 @@ func GetAssetDeltasFromFullExit(
 	return deltas
 }
 
-func GetNftDeltaFromFullExitNft() (nftDelta NftDeltaConstraints) {
+func GetNftDeltaFromFullExitNft(
+	api API,
+	flag Variable,
+	txInfo FullExitNftTxConstraints,
+	nftBefore NftConstraints) (nftDelta NftDeltaConstraints) {
+	isOwner := api.And(api.IsZero(api.Sub(txInfo.AccountIndex, nftBefore.OwnerAccountIndex)), flag)
+	creatorAccountIndex := api.Select(isOwner, types.ZeroInt, nftBefore.CreatorAccountIndex)
+	ownerAccountIndex := api.Select(isOwner, types.ZeroInt, nftBefore.OwnerAccountIndex)
+	nftContentHash := api.Select(isOwner, types.ZeroInt, nftBefore.NftContentHash)
+	creatorTreasuryRate := api.Select(isOwner, types.ZeroInt, nftBefore.CreatorTreasuryRate)
+	collectionId := api.Select(isOwner, types.ZeroInt, nftBefore.CollectionId)
 	nftDelta = NftDeltaConstraints{
-		CreatorAccountIndex: types.ZeroInt,
-		OwnerAccountIndex:   types.ZeroInt,
-		NftContentHash:      types.ZeroInt,
-		CreatorTreasuryRate: types.ZeroInt,
-		CollectionId:        types.ZeroInt,
+		CreatorAccountIndex: creatorAccountIndex,
+		OwnerAccountIndex:   ownerAccountIndex,
+		NftContentHash:      nftContentHash,
+		CreatorTreasuryRate: creatorTreasuryRate,
+		CollectionId:        collectionId,
 	}
 	return nftDelta
 }

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -283,7 +283,7 @@ func VerifyTransaction(
 	assetDeltasCheck = GetAssetDeltasFromFullExit(api, tx.FullExitTxInfo)
 	assetDeltas = SelectAssetDeltas(api, isFullExitTx, assetDeltasCheck, assetDeltas)
 	// full exit nft
-	nftDeltaCheck = GetNftDeltaFromFullExitNft()
+	nftDeltaCheck = GetNftDeltaFromFullExitNft(api, isFullExitNftTx, tx.FullExitNftTxInfo, tx.NftBefore)
 	nftDelta = SelectNftDeltas(api, isFullExitNftTx, nftDeltaCheck, nftDelta)
 	// update accounts
 	AccountsInfoAfter := UpdateAccounts(api, tx.AccountsInfoBefore, assetDeltas)
@@ -365,7 +365,8 @@ func VerifyTransaction(
 	newNftRoot := tx.NftRootBefore
 	api.AssertIsLessOrEqual(tx.NftBefore.NftIndex, LastNftIndex)
 	nftIndexMerkleHelper := NftIndexToMerkleHelper(api, tx.NftBefore.NftIndex)
-	nftNodeHash := poseidon.Poseidon(api, tx.NftBefore.CreatorAccountIndex,
+	nftNodeHash := poseidon.Poseidon(api,
+		tx.NftBefore.CreatorAccountIndex,
 		tx.NftBefore.OwnerAccountIndex,
 		tx.NftBefore.NftContentHash,
 		tx.NftBefore.CreatorTreasuryRate,

--- a/circuit/types/fullexit_nft.go
+++ b/circuit/types/fullexit_nft.go
@@ -81,9 +81,9 @@ func VerifyFullExitNftTx(
 	IsVariableEqual(api, flag, tx.AccountIndex, accountsBefore[fromAccount].AccountIndex)
 	IsVariableEqual(api, flag, tx.NftIndex, nftBefore.NftIndex)
 	IsVariableEqual(api, flag, tx.CreatorAccountIndex, accountsBefore[creatorAccount].AccountIndex)
-	IsVariableEqual(api, flag, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
-	IsVariableEqual(api, flag, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)
 	isOwner := api.And(api.IsZero(api.Sub(tx.AccountIndex, nftBefore.OwnerAccountIndex)), flag)
+	IsVariableEqual(api, isOwner, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
+	IsVariableEqual(api, isOwner, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)
 	IsVariableEqual(api, isOwner, tx.NftContentHash, nftBefore.NftContentHash)
 	tx.NftContentHash = api.Select(isOwner, tx.NftContentHash, 0)
 	return pubData

--- a/circuit/types/fullexit_nft.go
+++ b/circuit/types/fullexit_nft.go
@@ -81,6 +81,7 @@ func VerifyFullExitNftTx(
 	IsVariableEqual(api, flag, tx.AccountIndex, accountsBefore[fromAccount].AccountIndex)
 	IsVariableEqual(api, flag, tx.NftIndex, nftBefore.NftIndex)
 	IsVariableEqual(api, flag, tx.CreatorAccountIndex, accountsBefore[creatorAccount].AccountIndex)
+	IsVariableEqual(api, flag, tx.CreatorAccountNameHash, accountsBefore[creatorAccount].AccountNameHash)
 	isOwner := api.And(api.IsZero(api.Sub(tx.AccountIndex, nftBefore.OwnerAccountIndex)), flag)
 	IsVariableEqual(api, isOwner, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
 	IsVariableEqual(api, isOwner, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)


### PR DESCRIPTION
### Description

Fixes bunch of problems for FullExitNFT transactions:
1. Fixes proof validation for full exit of of NFTs which do not belong to user account.
2. Fixes proof validation for full exit of NFTs which were already withdrawn.

### Rationale

Prover service cannot generate no more proofs for blocks if there one of such full exit NFTs happened.

### Example

Run integration test where user tries to do full exit fo NFTs which do not belong to him/her or NFTs which were already withdrawn.

### Changes

Notable changes:
* NFT delta is calculated correctly for cases where full exit is happened for accounts which do not own this NFT.
* return back `CreatorAccountNameHash` validation in circuit.