### PR TITLE
Feature/diff block size

### DIFF
--- a/circuit/solidity/zkbnb_test.go
+++ b/circuit/solidity/zkbnb_test.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -31,10 +33,10 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/circuit"
 )
 
-var blockSize = flag.Int("blocksize", 10, "block size that will be used for proof generation and verification")
+var optionalBlockSizes = flag.String("blocksizes", "1,10", "block size that will be used for proof generation and verification")
 
 func TestCompileCircuit(t *testing.T) {
-	differentBlockSizes := []int{1, 10}
+	differentBlockSizes := optionalBlockSizesInt()
 	gasAssetIds := []int64{0, 1}
 	gasAccountIndex := int64(1)
 	for i := 0; i < len(differentBlockSizes); i++ {
@@ -56,11 +58,7 @@ func TestCompileCircuit(t *testing.T) {
 }
 
 func TestExportSol(t *testing.T) {
-	if *blockSize <= 0 {
-		panic(fmt.Sprintf("-blocksize arg is required to be bigger than %v", *blockSize))
-	}
-	differentBlockSizes := []int{1, *blockSize}
-	exportSol(differentBlockSizes)
+	exportSol(optionalBlockSizesInt())
 }
 
 func TestExportSolSmall(t *testing.T) {
@@ -111,4 +109,17 @@ func exportSol(differentBlockSizes []int) {
 			}
 		}
 	}
+}
+
+func optionalBlockSizesInt() []int {
+	blockSizesStr := strings.Split(*optionalBlockSizes, ",")
+	blockSizesInt := make([]int, len(blockSizesStr))
+	for i := range blockSizesStr {
+		v, err := strconv.Atoi(blockSizesStr[i])
+		if err != nil {
+			panic(err)
+		}
+		blockSizesInt[i] = v
+	}
+	return blockSizesInt
 }

--- a/circuit/solidity/zkbnb_test.go
+++ b/circuit/solidity/zkbnb_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/circuit"
 )
 
-var blockSize = flag.Int("blocksize", -1, "block size that will be used for proof generation and verification")
+var blockSize = flag.Int("blocksize", 10, "block size that will be used for proof generation and verification")
 
 func TestCompileCircuit(t *testing.T) {
 	differentBlockSizes := []int{1, 10}

--- a/circuit/solidity/zkbnb_test.go
+++ b/circuit/solidity/zkbnb_test.go
@@ -18,6 +18,7 @@
 package solidity
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -29,6 +30,8 @@ import (
 
 	"github.com/bnb-chain/zkbnb-crypto/circuit"
 )
+
+var blockSize = flag.Int("blocksize", -1, "block size that will be used for proof generation and verification")
 
 func TestCompileCircuit(t *testing.T) {
 	differentBlockSizes := []int{1, 10}
@@ -53,7 +56,10 @@ func TestCompileCircuit(t *testing.T) {
 }
 
 func TestExportSol(t *testing.T) {
-	differentBlockSizes := []int{1, 10}
+	if *blockSize <= 0 {
+		panic(fmt.Sprintf("-blocksize arg is required to be bigger than %v", *blockSize))
+	}
+	differentBlockSizes := []int{1, *blockSize}
 	exportSol(differentBlockSizes)
 }
 


### PR DESCRIPTION
### Description

Added support for pk, vk to be generated for different block size. Currently this is not supported from zkbnb side.

### Changes

Notable changes:
* added flag `-blockSize` in TestExportSol