### PR TITLE
bugfix: 1. add offer id constraint; 2. constrain offerId has 23 bits;

### DIFF
--- a/circuit/asset_delta.go
+++ b/circuit/asset_delta.go
@@ -350,7 +350,7 @@ func GetAssetDeltasAndNftDeltaFromAtomicMatch(
 	buyerDelta := api.Neg(api.Add(txInfo.BuyOffer.AssetAmount, RoyaltyAmountVar, buyChannelAmountVar, txInfo.BuyOffer.ProtocolAmount))
 	sellerDelta := sellerAmount
 	// buyer
-	buyOfferIdBits := api.ToBinary(txInfo.BuyOffer.OfferId, 23)
+	buyOfferIdBits := api.ToBinary(txInfo.BuyOffer.OfferId, types.OfferIdBitsConstrainLen)
 	buyAssetId := api.FromBinary(buyOfferIdBits[7:]...)
 	buyOfferIndex := api.Sub(txInfo.BuyOffer.OfferId, api.Mul(buyAssetId, OfferSizePerAsset))
 	buyOfferBits := api.ToBinary(accountsBefore[1].AssetsInfo[1].OfferCanceledOrFinalized)
@@ -372,7 +372,7 @@ func GetAssetDeltasAndNftDeltaFromAtomicMatch(
 		},
 	}
 	// sell
-	sellOfferIdBits := api.ToBinary(txInfo.SellOffer.OfferId, 23)
+	sellOfferIdBits := api.ToBinary(txInfo.SellOffer.OfferId, types.OfferIdBitsConstrainLen)
 	sellAssetId := api.FromBinary(sellOfferIdBits[7:]...)
 	sellOfferIndex := api.Sub(txInfo.SellOffer.OfferId, api.Mul(sellAssetId, OfferSizePerAsset))
 	sellOfferBits := api.ToBinary(accountsBefore[2].AssetsInfo[1].OfferCanceledOrFinalized)
@@ -458,7 +458,7 @@ func GetAssetDeltasFromCancelOffer(
 ) (deltas [NbAccountsPerTx][NbAccountAssetsPerAccount]AccountAssetDeltaConstraints,
 	gasDeltas [NbGasAssetsPerTx]GasDeltaConstraints) {
 	// from account
-	offerIdBits := api.ToBinary(txInfo.OfferId, 24)
+	offerIdBits := api.ToBinary(txInfo.OfferId, types.OfferIdBitsConstrainLen)
 	assetId := api.FromBinary(offerIdBits[7:]...)
 	offerIndex := api.Sub(txInfo.OfferId, api.Mul(assetId, OfferSizePerAsset))
 	fromOfferBits := api.ToBinary(accountsBefore[0].AssetsInfo[1].OfferCanceledOrFinalized)

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -108,6 +108,25 @@ func VerifyTransaction(
 	isFullExitTx := api.IsZero(api.Sub(tx.TxType, types.TxTypeFullExit))
 	isFullExitNftTx := api.IsZero(api.Sub(tx.TxType, types.TxTypeFullExitNft))
 
+	// make sure the tx type is supported
+	isSupportedTx := api.Add(
+		isEmptyTx,
+		isChangePubKey,
+		isDepositTx,
+		isDepositNftTx,
+		isTransferTx,
+		isWithdrawTx,
+		isCreateCollectionTx,
+		isMintNftTx,
+		isTransferNftTx,
+		isAtomicMatchTx,
+		isCancelOfferTx,
+		isWithdrawNftTx,
+		isFullExitTx,
+		isFullExitNftTx,
+	)
+	api.AssertIsEqual(isSupportedTx, 1)
+
 	// verify nonce
 	isLayer2Tx := api.Add(
 		isChangePubKey,

--- a/circuit/types/atomic_match.go
+++ b/circuit/types/atomic_match.go
@@ -191,22 +191,26 @@ func VerifyAtomicMatchTx(
 	IsVariableEqual(api, flag, tx.ProtocolAccountIndex, accountsBefore[protocolAccount].AccountIndex)
 
 	// verify buy offer id
-	buyOfferIdBits := api.ToBinary(tx.BuyOffer.OfferId, 24)
+	buyOfferIdBits := api.ToBinary(tx.BuyOffer.OfferId, OfferIdBitsConstrainLen)
 	buyAssetId := api.FromBinary(buyOfferIdBits[7:]...)
 	buyOfferIndex := api.Sub(tx.BuyOffer.OfferId, api.Mul(buyAssetId, OfferSizePerAsset))
 	buyOfferIndexBits := api.ToBinary(accountsBefore[buyAccount].AssetsInfo[1].OfferCanceledOrFinalized, OfferSizePerAsset)
+	IsVariableEqual(api, flag, buyAssetId, accountsBefore[buyAccount].AssetsInfo[1].AssetId)
 	for i := 0; i < OfferSizePerAsset; i++ {
 		isZero := api.IsZero(api.Sub(buyOfferIndex, i))
-		IsVariableEqual(api, isZero, buyOfferIndexBits[i], 0)
+		isCheck := api.And(isZero, flag)
+		IsVariableEqual(api, isCheck, buyOfferIndexBits[i], 0)
 	}
 	// verify sell offer id
-	sellOfferIdBits := api.ToBinary(tx.SellOffer.OfferId, 24)
+	sellOfferIdBits := api.ToBinary(tx.SellOffer.OfferId, OfferIdBitsConstrainLen)
 	sellAssetId := api.FromBinary(sellOfferIdBits[7:]...)
 	sellOfferIndex := api.Sub(tx.SellOffer.OfferId, api.Mul(sellAssetId, OfferSizePerAsset))
 	sellOfferIndexBits := api.ToBinary(accountsBefore[sellAccount].AssetsInfo[1].OfferCanceledOrFinalized, OfferSizePerAsset)
+	IsVariableEqual(api, flag, sellAssetId, accountsBefore[sellAccount].AssetsInfo[1].AssetId)
 	for i := 0; i < OfferSizePerAsset; i++ {
 		isZero := api.IsZero(api.Sub(sellOfferIndex, i))
-		IsVariableEqual(api, isZero, sellOfferIndexBits[i], 0)
+		isCheck := api.And(isZero, flag)
+		IsVariableEqual(api, isCheck, sellOfferIndexBits[i], 0)
 	}
 	// buyer should have enough balance
 	tx.BuyOffer.AssetAmount = UnpackAmount(api, tx.BuyOffer.AssetAmount)

--- a/circuit/types/typesize.go
+++ b/circuit/types/typesize.go
@@ -34,4 +34,7 @@ const (
 	AccountNameBitsSize  = 160
 	HashBitsSize         = 256
 	PubkeyBitsSize       = 256
+
+	// for constrain the offerId is in [0, 2^23-1]
+	OfferIdBitsConstrainLen       = 23
 )


### PR DESCRIPTION
### Description

This commit fixed several bugs about `offerId` for `AtomicMatch` and `CancelOffer` tx. And make sure the tx type is supported.

### Rationale


### Example


### Changes

Notable changes:
* Constrain `offerId` to be in range [0, 2^23-1]
* Constrain the `assetId` which decided by `offerId` to be equal to `assetId` of account provided by witness
* Constrain the `offerId` in `CancelOffer` tx is not used
* Add constraint which guarantee tx type is supported