### PR TITLE
Fix certik audit

### DIFF
--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -51,7 +51,7 @@ type TxConstraints struct {
 	Signature SignatureConstraints
 	// account root before
 	AccountRootBefore Variable
-	// account before info, size is 4
+	// account before info, size is 7
 	AccountsInfoBefore [NbAccountsPerTx]types.AccountConstraints
 	// nft root before
 	NftRootBefore Variable

--- a/ecc/ztwistededwards/tebn254/eddsa.go
+++ b/ecc/ztwistededwards/tebn254/eddsa.go
@@ -20,14 +20,10 @@ package tebn254
 import (
 	"bytes"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/hex"
-	"io"
-	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards"
-	"golang.org/x/crypto/blake2b"
+	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa"
 )
 
 /*
@@ -41,7 +37,7 @@ func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
 	// calc hash by using sha256 to not lose seed data
 	hash := sha256.Sum256(buf)
 	reader := bytes.NewReader(hash[:])
-	sk, err = GenerateKey(reader)
+	sk, err = eddsa.GenerateKey(reader)
 	return sk, err
 }
 
@@ -49,67 +45,3 @@ const (
 	sizeFr = fr.Bytes
 )
 
-func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
-	c := twistededwards.GetEdwardsCurve()
-
-	var (
-		randSrc = make([]byte, 32)
-		scalar  = make([]byte, 32)
-		pub     PublicKey
-	)
-
-	// hash(h) = private_key || random_source, on 32 bytes each
-	seed := make([]byte, 32)
-	_, err := r.Read(seed)
-	if err != nil {
-		return nil, err
-	}
-	h := blake2b.Sum512(seed[:])
-	for i := 0; i < 32; i++ {
-		randSrc[i] = h[i+32]
-	}
-
-	// prune the key
-	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
-
-	h[0] &= 0xF8
-	h[31] &= 0x7F
-	h[31] |= 0x40
-
-	/*
-		0xFC = 1111 1100
-		convert 256 bits to 254 bits supporting bn254 curve
-	*/
-	h[31] &= 0xFC
-
-	// reverse first bytes because setBytes interpret stream as big endian
-	// but in eddsa specs s is the first 32 bytes in little endian
-	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
-		scalar[i] = h[j]
-	}
-
-	a := new(big.Int).SetBytes(scalar[:])
-	for i := 253; i < 256; i++ {
-		a.SetBit(a, i, 0)
-	}
-
-	copy(scalar[:], a.FillBytes(make([]byte, 32)))
-
-	var bscalar big.Int
-	bscalar.SetBytes(scalar[:])
-	pub.A.ScalarMultiplication(&c.Base, &bscalar)
-
-	var res [sizeFr * 3]byte
-	pubkBin := pub.A.Bytes()
-	subtle.ConstantTimeCopy(1, res[:sizeFr], pubkBin[:])
-	subtle.ConstantTimeCopy(1, res[sizeFr:2*sizeFr], scalar[:])
-	subtle.ConstantTimeCopy(1, res[2*sizeFr:], randSrc[:])
-
-	var sk = &PrivateKey{}
-	// make sure sk is not nil
-
-	_, err = sk.SetBytes(res[:])
-
-	return sk, err
-}

--- a/ecc/ztwistededwards/tebn254/eddsa_test.go
+++ b/ecc/ztwistededwards/tebn254/eddsa_test.go
@@ -19,20 +19,18 @@ package tebn254
 
 import (
 	"log"
-	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 )
 
 func TestGenerateEddsaPrivateKey(t *testing.T) {
-	sk, err := GenerateEddsaPrivateKey("testeeetgcxsaahsadcastzxbmjhgmgjhcarwewfseasdasdavacsafaewe")
+	sk, err := GenerateEddsaPrivateKey("0123456789abcdef0123456789abcdef")
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Println(new(big.Int).SetBytes(sk.Bytes()[32:64]).BitLen())
 	hFunc := mimc.NewMiMC()
-	hFunc.Write([]byte("sher"))
+	hFunc.Write([]byte("0123456789abcdef0123456789abcdef"))
 	msg := hFunc.Sum(nil)
 	hFunc.Reset()
 	signMsg, err := sk.Sign(msg, hFunc)

--- a/ecc/ztwistededwards/tebn254/tebn254.go
+++ b/ecc/ztwistededwards/tebn254/tebn254.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards"
 
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
@@ -109,12 +108,11 @@ func MapToGroup(seed string) (H *Point, err error) {
 		buffer bytes.Buffer
 	)
 	i = 0
-	hmimc := mimc.NewMiMC()
 	for i < 256 {
 		buffer.Reset()
 		buffer.WriteString(seed)
 		buffer.WriteString(strconv.Itoa(i))
-		y, err := util.HashToInt(buffer, hmimc)
+		y, err := util.HashToInt(buffer)
 		if err != nil {
 			return nil, err
 		}

--- a/ffmath/ffmath.go
+++ b/ffmath/ffmath.go
@@ -27,9 +27,7 @@ func Add(x *big.Int, y *big.Int) *big.Int {
 }
 
 func AddMod(x, y *big.Int, ORDER *big.Int) *big.Int {
-	res := Add(x, y)
-	res = Mod(res, ORDER)
-	return res
+	return Mod(Add(x,y), ORDER)
 }
 
 func Sub(x *big.Int, y *big.Int) *big.Int {
@@ -37,9 +35,7 @@ func Sub(x *big.Int, y *big.Int) *big.Int {
 }
 
 func SubMod(x, y *big.Int, ORDER *big.Int) *big.Int {
-	res := Sub(x, y)
-	res = Mod(res, ORDER)
-	return res
+	return Mod(Sub(x, y), ORDER)
 }
 
 func Mod(base *big.Int, modulo *big.Int) *big.Int {
@@ -51,9 +47,7 @@ func Multiply(factor1 *big.Int, factor2 *big.Int) *big.Int {
 }
 
 func MultiplyMod(factor1 *big.Int, factor2 *big.Int, ORDER *big.Int) *big.Int {
-	res := Multiply(factor1, factor2)
-	res = Mod(res, ORDER)
-	return res
+	return Mod(Multiply(factor1, factor2), ORDER)
 }
 
 func Div(a, b *big.Int) *big.Int {

--- a/util/hash.go
+++ b/util/hash.go
@@ -19,20 +19,26 @@ package util
 
 import (
 	"bytes"
-	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"hash"
+	"errors"
 	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 )
 
-func HashToInt(b bytes.Buffer, h hash.Hash) (*big.Int, error) {
-	h = mimc.NewMiMC()
-	digest := h
+func HashToInt(b bytes.Buffer) (*big.Int, error) {
+	if b.Len() == 0 {
+		return nil, errors.New("input is empty")
+	}
+	digest := mimc.NewMiMC()
 	var x fr.Element
 	_ = x.SetBytes(b.Bytes())
 	bs := x.Bytes()
-	digest.Write(bs[:])
+	_, err := digest.Write(bs[:])
+	if err != nil {
+		return nil, err
+	}
 	output := digest.Sum(nil)
 	//tmp := output[0:]
 	//return FromByteArray(tmp)


### PR DESCRIPTION
### Description

This is the first commit which used to fix the audit suggestion from certik

### Rationale


### Example


### Changes

Notable changes:
* Optimize some codes;
* Change the eddsa private key generation, use the gnark-crypto's implementation 